### PR TITLE
Pico 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+Pico Composer Installer Changelog
+=================================
+
+**Note:** This changelog only provides technical information about the changes
+          introduced with a particular version, and is meant to supplement the
+          actual code changes. The information in this changelog are often
+          insufficient to understand the implications of larger changes. Please
+          refer to both the UPGRADE and NEWS sections of the docs for more
+          details.
+
+### Version 1.0.1
+Released: 2019-11-24
+
+```
+* [Changed] Code cleanup
+* [Changed] Remove unused code
+* [Changed] Improve PHPDoc class docs
+```
+
+### Version 1.0.0
+Released: 2017-10-13
+
+```
+* Initial release
+```

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
     "license": "MIT",
     "authors": [
         {
+            "name": "Daniel Rudolf",
+            "email": "picocms.org@daniel-rudolf.de",
+            "role": "Lead Developer"
+        },
+        {
             "name": "The Pico Community",
             "homepage": "http://picocms.org/"
         },

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -162,7 +162,6 @@ class PluginInstaller extends \Composer\Installer\LibraryInstaller
      * a mapping of Composer package to Pico plugin class names.
      *
      * @param \Composer\Script\Event $event
-     * @return void
      */
     public static function postAutoloadDump(\Composer\Script\Event $event)
     {
@@ -412,7 +411,6 @@ class PluginInstaller extends \Composer\Installer\LibraryInstaller
      * @param  string $pluginConfig
      * @param  array  $plugins
      * @param  array  $pluginClassNames
-     * @return void
      */
     public static function writePluginConfig($pluginConfig, array $plugins, array $pluginClassNames)
     {

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -264,7 +264,7 @@ class PluginInstaller extends LibraryInstaller
         // 1. root package
         $rootPackageExtra = $rootPackage ? $rootPackage->getExtra() : null;
         if (!empty($rootPackageExtra[$packageType])) {
-            $classNames = (array) $this->mapRootExtra($rootPackageExtra[$packageType], $packagePrettyName);
+            $classNames = (array) static::mapRootExtra($rootPackageExtra[$packageType], $packagePrettyName);
         }
 
         // 2. package
@@ -308,7 +308,7 @@ class PluginInstaller extends LibraryInstaller
 
         $rootPackageExtra = $rootPackage ? $rootPackage->getExtra() : null;
         if (!empty($rootPackageExtra['installer-name'])) {
-            $installName = $this->mapRootExtra($rootPackageExtra['installer-name'], $packagePrettyName);
+            $installName = static::mapRootExtra($rootPackageExtra['installer-name'], $packagePrettyName);
         }
 
         if (!$installName) {

--- a/src/Installer/PluginInstaller.php
+++ b/src/Installer/PluginInstaller.php
@@ -85,10 +85,10 @@ class PluginInstaller extends LibraryInstaller
     /**
      * Initializes Pico plugin and theme installer
      *
-     * This method tries to automatically register the `post-autoload-dump`
-     * script ({@see static::postAutoloadDump()}), if it wasn't explicitly set
-     * already. If this isn't possible, the autoload dump event consequently
-     * can't be used ({@see static::checkAutoloadDump()}).
+     * This method tries to register the `post-autoload-dump` script
+     * ({@see PluginInstaller::postAutoloadDump()}), if it wasn't explicitly
+     * set already. If this isn't possible, the autoload dump event can't be
+     * used ({@see PluginInstaller::checkAutoloadDump()}).
      *
      * @param IOInterface     $io
      * @param Composer        $composer
@@ -127,9 +127,9 @@ class PluginInstaller extends LibraryInstaller
     /**
      * Checks whether the autoload dump event is used
      *
-     * Using the autoload dump event is synonymous with creating the
-     * `pico-plugin.php` in Composer's vendor dir. Plugins are nevertheless
-     * installed to Pico's `plugins/` dir ({@see static::getInstallPath()}).
+     * Using the autoload dump event will always create `pico-plugin.php` in
+     * Composer's vendor dir. Plugins are nevertheless installed to Pico's
+     * `plugins/` dir ({@see PluginInstaller::getInstallPath()}).
      *
      * The autoload dump event is used when the root package is a project and
      * explicitly requires this composer installer.
@@ -222,7 +222,7 @@ class PluginInstaller extends LibraryInstaller
      * package's or the plugin package's `composer.json`, or are derived
      * implicitly from the plugin's installer name. The installer name is, for
      * its part, either specified explicitly, or derived implicitly from the
-     * plugin package's name ({@see static::getInstallName()}).
+     * plugin package's name ({@see PluginInstaller::getInstallName()}).
      *
      * 1. Using the "pico-plugin" extra in the root package's `composer.json`:
      *    ```yaml
@@ -235,8 +235,8 @@ class PluginInstaller extends LibraryInstaller
      *    }
      *    ```
      *
-     *    Besides matching the exact package name, you can also use the
-     *    `vendor:` or `name:` prefixes. See {@see static::mapRootExtra()}.
+     *    Besides matching exact package names, you can also use the prefixes
+     *    `vendor:` or `name:` ({@see PluginInstaller::mapRootExtra()}).
      *
      * 2. Using the "pico-plugin" extra in the package's `composer.json`:
      *    ```yaml
@@ -247,7 +247,7 @@ class PluginInstaller extends LibraryInstaller
      *    }
      *    ```
      *
-     * 3. Using the installer name. See {@see static::getInstallName()}.
+     * 3. Using the installer name ({@see PluginInstaller::getInstallName()}).
      *
      * @param PackageInterface      $package
      * @param PackageInterface|null $rootPackage
@@ -293,7 +293,7 @@ class PluginInstaller extends LibraryInstaller
      * name.
      *
      * Install names are determined the same way as plugin class names. See
-     * {@see static::getPluginClassNames()} for details.
+     * {@see PluginInstaller::getPluginClassNames()} for details.
      *
      * @param PackageInterface      $package
      * @param PackageInterface|null $rootPackage


### PR DESCRIPTION
> Pico 2.1 mostly targets the mostly completed rewrite of Pico CMS for Nextcloud, which is going to be a officially supported by Pico. This is a minor release. This release includes new features, but doesn't break BC with older releases of Pico when using Pico's official `PicoDeprecated` plugin.
>
> As always, **feedback is highly appreciated!**

Please use this PR for code reviews only, for a list of major changes and for comments please refer to https://github.com/picocms/Pico/pull/515